### PR TITLE
Validate ObjectVersionId value

### DIFF
--- a/src/Base/BaseTypes/Identification/ObjectVersionId.php
+++ b/src/Base/BaseTypes/Identification/ObjectVersionId.php
@@ -2,9 +2,14 @@
 
 namespace BigPictureMedical\OpenEhr\Base\BaseTypes\Identification;
 
+use BigPictureMedical\OpenEhr\Validators\ValidObjectVersionId;
+
 class ObjectVersionId extends UidBasedId
 {
     public string $_type = 'OBJECT_VERSION_ID';
+
+    #[ValidObjectVersionId()]
+    public string $value;
 
     public function object_id(): Uid
     {

--- a/src/Validators/ValidObjectVersionId.php
+++ b/src/Validators/ValidObjectVersionId.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BigPictureMedical\OpenEhr\Validators;
+
+use Attribute;
+use Spatie\DataTransferObject\Validation\ValidationResult;
+use Spatie\DataTransferObject\Validator;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class ValidObjectVersionId implements Validator
+{
+    public function validate(mixed $value): ValidationResult
+    {
+        if (! is_string($value)) {
+            return ValidationResult::invalid('Value must be a string.');
+        }
+
+        if (preg_match('/^.*::.*::[0-9.]*$/', $value) !== 1) {
+            return ValidationResult::invalid('Value is not valid lexical form: object_id \'::\' creating_system_id \'::\' version_tree_id');
+        }
+
+        return ValidationResult::valid();
+    }
+}

--- a/tests/ObjectVersionIdTest.php
+++ b/tests/ObjectVersionIdTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests;
+
+use BigPictureMedical\OpenEhr\Base\BaseTypes\Identification\ObjectVersionId;
+use BigPictureMedical\OpenEhr\Base\BaseTypes\Identification\Uid;
+use BigPictureMedical\OpenEhr\Base\BaseTypes\Identification\VersionTreeId;
+use PHPUnit\Framework\TestCase;
+use Spatie\DataTransferObject\Exceptions\ValidationException;
+
+class ObjectVersionIdTest extends TestCase
+{
+    public function test_it_allows_access_to_individual_version_parts()
+    {
+        $objectVersionId = new ObjectVersionId(['value' => 'f98fb962-2f66-4810-bd9e-d3dba46fcdc5::example.openehr.org::1']);
+
+        $this->assertInstanceOf(Uid::class, $objectVersionId->object_id());
+        $this->assertEquals('f98fb962-2f66-4810-bd9e-d3dba46fcdc5', $objectVersionId->object_id()->value);
+
+        $this->assertInstanceOf(Uid::class, $objectVersionId->creating_system_id());
+        $this->assertEquals('example.openehr.org', $objectVersionId->creating_system_id()->value);
+
+        $this->assertInstanceOf(VersionTreeId::class, $objectVersionId->version_tree_id());
+        $this->assertEquals('1', $objectVersionId->version_tree_id()->value);
+    }
+
+    public function test_it_validates_badly_formatted_versions()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("Value is not valid lexical form: object_id '::' creating_system_id '::' version_tree_id");
+
+        new ObjectVersionId(['value' => 'bad']);
+    }
+}


### PR DESCRIPTION
Ensure that the ObjectVersionId value matches the lexical form specified at https://specifications.openehr.org/releases/BASE/latest/base_types.html#_object_version_id_class:

```
object_id '::' creating_system_id '::' version_tree_id
```

Prevents an unhelpful error where accessing the `creating_system_id()` and `version_tree_id()` when the value is bad.