### PR TITLE
Add PROPORTION_KIND constants to DV_PROPORTION

### DIFF
--- a/src/Rm/DataTypes/Quantity/DvProportion.php
+++ b/src/Rm/DataTypes/Quantity/DvProportion.php
@@ -4,15 +4,15 @@ namespace BigPictureMedical\OpenEhr\Rm\DataTypes\Quantity;
 
 class DvProportion extends DvAmount
 {
-    public const PK_RATIO = 0;
+    public const PK_RATIO = ProportionKind::PK_RATIO;
 
-    public const PK_UNITARY = 1;
+    public const PK_UNITARY = ProportionKind::PK_UNITARY;
 
-    public const PK_PERCENT = 2;
+    public const PK_PERCENT = ProportionKind::PK_PERCENT;
 
-    public const PK_FRACTION = 3;
+    public const PK_FRACTION = ProportionKind::PK_FRACTION;
 
-    public const PK_INTEGER_FRACTION = 4;
+    public const PK_INTEGER_FRACTION = ProportionKind::PK_INTEGER_FRACTION;
 
     public string $_type = 'DV_PROPORTION';
 

--- a/src/Rm/DataTypes/Quantity/DvProportion.php
+++ b/src/Rm/DataTypes/Quantity/DvProportion.php
@@ -4,6 +4,16 @@ namespace BigPictureMedical\OpenEhr\Rm\DataTypes\Quantity;
 
 class DvProportion extends DvAmount
 {
+    public const PK_RATIO = 0;
+
+    public const PK_UNITARY = 1;
+
+    public const PK_PERCENT = 2;
+
+    public const PK_FRACTION = 3;
+
+    public const PK_INTEGER_FRACTION = 4;
+
     public string $_type = 'DV_PROPORTION';
 
     public float $numerator;

--- a/src/Rm/DataTypes/Quantity/ProportionKind.php
+++ b/src/Rm/DataTypes/Quantity/ProportionKind.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BigPictureMedical\OpenEhr\Rm\DataTypes\Quantity;
+
+class ProportionKind
+{
+    public const PK_RATIO = 0;
+
+    public const PK_UNITARY = 1;
+
+    public const PK_PERCENT = 2;
+
+    public const PK_FRACTION = 3;
+
+    public const PK_INTEGER_FRACTION = 4;
+}


### PR DESCRIPTION
The [`DV_PROPORTION`](https://specifications.openehr.org/releases/RM/Release-1.1.0/data_types.html#_dv_proportion_class) specification defines that the class inherit two classes, `DV_AMOUNT` and `PROPORTION_KIND`. The latter adds some constants for defining the value of the `DV_PROPORTION` `type` attribute.

As PHP doesn't support multiple inheritance, I have duplicated the constants in `DvProportion`, but referenced the values from the new `ProportionKind` class. Additionally, I have made them uppercase to keep with PHP conventions.