### PR TITLE
Add itemAtPath and itemsAtPath methods to Pathable class

### DIFF
--- a/src/PathQuery.php
+++ b/src/PathQuery.php
@@ -31,10 +31,13 @@ class PathQuery
 
         foreach ($this->segments() as $segment) {
             $items = $items
-                ->map(fn ($item) => $item->{$segment['attribute_name']})->flatten()
+                ->map(fn ($item) => $item->{$segment['attribute_name']})
+                ->flatten()
                 ->when(
                     isset($segment['expression']),
-                    fn ($items) => $items->filter(fn ($item) => $item->archetype_node_id === $segment['expression'])
+                    fn ($items) => $items
+                        ->filter(fn ($item) => $item->archetype_node_id === $segment['expression'])
+                        ->values()
                 );
         }
 

--- a/src/PathQuery.php
+++ b/src/PathQuery.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BigPictureMedical\OpenEhr;
+
+use Illuminate\Support\Collection;
+
+class PathQuery
+{
+    public function __construct(protected $query) {}
+
+    public function find(object $root)
+    {
+        $item = $root;
+
+        foreach ($this->segments() as $segment) {
+            if (! isset($segment['expression'])) {
+                $item = $item?->{$segment['attribute_name']};
+                continue;
+            }
+
+            $item = collect($item?->{$segment['attribute_name']})->firstWhere('archetype_node_id', $segment['expression']);
+        }
+
+        return $item;
+    }
+
+    public function findList(object $root)
+    {
+        $items = collect([$root]);
+
+        foreach ($this->segments() as $segment) {
+            $items = $items
+                ->map(fn ($item) => $item->{$segment['attribute_name']})->flatten()
+                ->when(
+                    isset($segment['expression']),
+                    fn ($items) => $items->filter(fn ($item) => $item->archetype_node_id === $segment['expression'])
+                );
+        }
+
+        return $items->toArray();
+    }
+
+    private function segments(): Collection
+    {
+        return collect(explode('/', $this->query))->map(function ($segment) {
+            $attributePattern = '(?<attribute_name>\w+)';
+            $predicatePattern = '(?<predicate>\[(?<expression>[\w.-]+)\])?';
+            if (preg_match('/^' . $attributePattern . $predicatePattern . '$/', $segment, $matches) !== 1) {
+                throw new \Exception("Unable to parse path segment [$segment]");
+            }
+
+            if (! array_key_exists('attribute_name', $matches)) {
+                throw new \Exception("Unable to find attribute_name in path segment [$segment]");
+            }
+
+            return $matches;
+        });
+    }
+}

--- a/src/PathQuery.php
+++ b/src/PathQuery.php
@@ -2,13 +2,14 @@
 
 namespace BigPictureMedical\OpenEhr;
 
+use BigPictureMedical\OpenEhr\Rm\Common\Archetyped\Pathable;
 use Illuminate\Support\Collection;
 
 class PathQuery
 {
-    public function __construct(protected $query) {}
+    public function __construct(protected string $query) {}
 
-    public function find(object $root)
+    public function find(Pathable $root): mixed
     {
         $item = $root;
 
@@ -24,7 +25,7 @@ class PathQuery
         return $item;
     }
 
-    public function findList(object $root)
+    public function findList(Pathable $root): array
     {
         $items = collect([$root]);
 

--- a/src/Rm/Common/Archetyped/Pathable.php
+++ b/src/Rm/Common/Archetyped/Pathable.php
@@ -3,8 +3,19 @@
 namespace BigPictureMedical\OpenEhr\Rm\Common\Archetyped;
 
 use BigPictureMedical\OpenEhr\Base\FoundationTypes\Any;
+use BigPictureMedical\OpenEhr\PathQuery;
 
 abstract class Pathable extends Any
 {
     public string $_type = 'PATHABLE';
+
+    public function itemAtPath(string $path): mixed
+    {
+        return (new PathQuery($path))->find($this);
+    }
+
+    public function itemsAtPath(string $path): array
+    {
+        return (new PathQuery($path))->findList($this);
+    }
 }

--- a/tests/PathQueryTest.php
+++ b/tests/PathQueryTest.php
@@ -27,6 +27,17 @@ class PathQueryTest extends TestCase
         $this->assertSame('Test value 1', $result);
     }
 
+    public function test_it_handles_missing_paths_when_finding_a_single_item()
+    {
+        $composition = $this->makeComposition();
+
+        $query = 'content[missing]/data/items[at0002]/items[at0003]/value/value';
+
+        $result = (new PathQuery($query))->find($composition);
+
+        $this->assertSame(null, $result);
+    }
+
     public function test_it_finds_a_list()
     {
         $composition = $this->makeComposition();
@@ -41,6 +52,17 @@ class PathQueryTest extends TestCase
             'Test value 3',
             'Test value 4',
         ], $result);
+    }
+
+    public function test_it_handles_missing_paths_when_finding_a_list()
+    {
+        $composition = $this->makeComposition();
+
+        $query = 'content[missing]/data/items[at0002]/items[at0003]/value/value';
+
+        $result = (new PathQuery($query))->findList($composition);
+
+        $this->assertSame([], $result);
     }
 
     private function makeComposition(): Composition

--- a/tests/PathQueryTest.php
+++ b/tests/PathQueryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests;
+
+use BigPictureMedical\OpenEhr\PathQuery;
+use BigPictureMedical\OpenEhr\Rm\Common\Generic\PartySelf;
+use BigPictureMedical\OpenEhr\Rm\Composition\Composition;
+use BigPictureMedical\OpenEhr\Rm\Composition\Content\Entry\Evaluation;
+use BigPictureMedical\OpenEhr\Rm\DataStructures\ItemStructure\ItemTree;
+use BigPictureMedical\OpenEhr\Rm\DataStructures\Representation\Cluster;
+use BigPictureMedical\OpenEhr\Rm\DataStructures\Representation\Element;
+use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\CodePhrase;
+use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvCodedText;
+use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvText;
+use PHPUnit\Framework\TestCase;
+
+class PathQueryTest extends TestCase
+{
+    public function test_it_finds_a_single_item()
+    {
+        $composition = $this->makeComposition();
+
+        $query = 'content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value';
+
+        $result = (new PathQuery($query))->find($composition);
+
+        $this->assertSame('Test value 1', $result);
+    }
+
+    public function test_it_finds_a_list()
+    {
+        $composition = $this->makeComposition();
+
+        $query = 'content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value';
+
+        $result = (new PathQuery($query))->findList($composition);
+
+        $this->assertSame([
+            'Test value 1',
+            'Test value 2',
+            'Test value 3',
+            'Test value 4',
+        ], $result);
+    }
+
+    private function makeComposition(): Composition
+    {
+        return new Composition(
+            archetype_node_id: 'test-COMPOSITION.test.v0',
+            name: new DvText(value: 'Test composition'),
+            language: CodePhrase::make('test', 'test'),
+            territory: CodePhrase::make('test', 'test'),
+            category: DvCodedText::make('test', 'test', 'test'),
+            composer: new PartySelf(),
+            content: [
+                new Evaluation(
+                    archetype_node_id: 'test-EVALUATION.test.v0',
+                    name: new DvText(value: 'Test evaluation'),
+                    language: CodePhrase::make('test', 'test'),
+                    encoding: CodePhrase::make('test', 'test'),
+                    subject: new PartySelf(),
+                    provider: new PartySelf(),
+                    data: new ItemTree(
+                        archetype_node_id: 'at0001',
+                        name: new DvText(value: 'data'),
+                        items: [
+                            new Cluster(
+                                name: new DvText(value: 'Test cluster'),
+                                archetype_node_id: 'at0002',
+                                items: [
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 1')
+                                    ),
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 2')
+                                    ),
+                                ]
+                            ),
+                            new Cluster(
+                                name: new DvText(value: 'Test cluster'),
+                                archetype_node_id: 'at0002',
+                                items: [
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 3')
+                                    ),
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 4')
+                                    ),
+                                ]
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        );
+    }
+}

--- a/tests/PathableTest.php
+++ b/tests/PathableTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests;
+
+use BigPictureMedical\OpenEhr\Rm\Common\Generic\PartySelf;
+use BigPictureMedical\OpenEhr\Rm\Composition\Composition;
+use BigPictureMedical\OpenEhr\Rm\Composition\Content\Entry\Evaluation;
+use BigPictureMedical\OpenEhr\Rm\DataStructures\ItemStructure\ItemTree;
+use BigPictureMedical\OpenEhr\Rm\DataStructures\Representation\Cluster;
+use BigPictureMedical\OpenEhr\Rm\DataStructures\Representation\Element;
+use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\CodePhrase;
+use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvCodedText;
+use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvText;
+use PHPUnit\Framework\TestCase;
+
+class PathableTest extends TestCase
+{
+    public function test_it_finds_an_item_at_path()
+    {
+        $composition = $this->makeComposition();
+
+        $result = $composition->itemAtPath('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value');
+
+        $this->assertSame('Test value 1', $result);
+    }
+
+    public function test_it_finds_items_at_path()
+    {
+        $composition = $this->makeComposition();
+
+        $result = $composition->itemsAtPath('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value');
+
+        $this->assertSame([
+            'Test value 1',
+            'Test value 2',
+            'Test value 3',
+            'Test value 4',
+        ], $result);
+    }
+
+    private function makeComposition(): Composition
+    {
+        return new Composition(
+            archetype_node_id: 'test-COMPOSITION.test.v0',
+            name: new DvText(value: 'Test composition'),
+            language: CodePhrase::make('test', 'test'),
+            territory: CodePhrase::make('test', 'test'),
+            category: DvCodedText::make('test', 'test', 'test'),
+            composer: new PartySelf(),
+            content: [
+                new Evaluation(
+                    archetype_node_id: 'test-EVALUATION.test.v0',
+                    name: new DvText(value: 'Test evaluation'),
+                    language: CodePhrase::make('test', 'test'),
+                    encoding: CodePhrase::make('test', 'test'),
+                    subject: new PartySelf(),
+                    provider: new PartySelf(),
+                    data: new ItemTree(
+                        archetype_node_id: 'at0001',
+                        name: new DvText(value: 'data'),
+                        items: [
+                            new Cluster(
+                                name: new DvText(value: 'Test cluster'),
+                                archetype_node_id: 'at0002',
+                                items: [
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 1')
+                                    ),
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 2')
+                                    ),
+                                ]
+                            ),
+                            new Cluster(
+                                name: new DvText(value: 'Test cluster'),
+                                archetype_node_id: 'at0002',
+                                items: [
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 3')
+                                    ),
+                                    new Element(
+                                        archetype_node_id: 'at0003',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test value 4')
+                                    ),
+                                ]
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Adds `itemAtPath($path)` and `itemsAtPath($path)` methods to `Pathable`, allowing most classes to search child nodes using an XPath-style path.

These methods are described in the [PATHABLE specification](https://specifications.openehr.org/releases/RM/latest/common.html#_pathable_class) with further details on the paths available in the [Paths section](https://specifications.openehr.org/releases/BASE/latest/architecture_overview.html#_paths_and_locators) of the openEHR archetype overview.

Currently only simple predicates containing the `archetype_node_id` are supported.

Example:

```php
$evaluation->itemAtPath(`data/items[at0001]/items[at0004]/value/value`);
```

Inspiration taken from ["archie"](https://github.com/openEHR/archie/blob/985e1318546742d022905b9ac778e61190373c82/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java) and special thanks to @timacdonald for having already written the regular expressions.