### PR TITLE
Add pathExists() and pathUnique() to Pathable

### DIFF
--- a/src/PathQuery.php
+++ b/src/PathQuery.php
@@ -21,6 +21,7 @@ class PathQuery
         foreach ($this->segments() as $segment) {
             $items = $items
                 ->map(fn ($item) => $item->{$segment['attribute_name']} ?? null)
+                ->filter()
                 ->flatten()
                 ->when(
                     isset($segment['expression']),

--- a/src/PathQuery.php
+++ b/src/PathQuery.php
@@ -34,6 +34,16 @@ class PathQuery
         return $items->toArray();
     }
 
+    public function exists(Pathable $root): bool
+    {
+        return count($this->findList($root)) > 0;
+    }
+
+    public function unique(Pathable $root): bool
+    {
+        return count($this->findList($root)) === 1;
+    }
+
     private function segments(): Collection
     {
         return collect(explode('/', $this->query))->map(function ($segment) {

--- a/src/Rm/Common/Archetyped/Pathable.php
+++ b/src/Rm/Common/Archetyped/Pathable.php
@@ -18,4 +18,14 @@ abstract class Pathable extends Any
     {
         return (new PathQuery($path))->findList($this);
     }
+
+    public function pathExists(string $path): bool
+    {
+        return (new PathQuery($path))->exists($this);
+    }
+
+    public function pathUnique(string $path): bool
+    {
+        return (new PathQuery($path))->unique($this);
+    }
 }

--- a/tests/PathQueryTest.php
+++ b/tests/PathQueryTest.php
@@ -74,6 +74,10 @@ class PathQueryTest extends TestCase
         $result = (new PathQuery('missing[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value'))
             ->findList($composition);
         $this->assertSame([], $result);
+
+        $result = (new PathQuery('test'))
+            ->findList($composition);
+        $this->assertSame([], $result);
     }
 
     private function makeComposition(): Composition

--- a/tests/PathQueryTest.php
+++ b/tests/PathQueryTest.php
@@ -80,6 +80,32 @@ class PathQueryTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function test_it_finds_whether_a_path_exists()
+    {
+        $composition = $this->makeComposition();
+
+        $result = (new PathQuery('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value'))
+            ->exists($composition);
+        $this->assertTrue($result);
+
+        $result = (new PathQuery('test'))
+            ->exists($composition);
+        $this->assertFalse($result);
+    }
+
+    public function test_it_finds_whether_a_path_is_unique()
+    {
+        $composition = $this->makeComposition();
+
+        $result = (new PathQuery('content[test-EVALUATION.test.v0]/data'))
+            ->unique($composition);
+        $this->assertTrue($result);
+
+        $result = (new PathQuery('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value'))
+            ->unique($composition);
+        $this->assertFalse($result);
+    }
+
     private function makeComposition(): Composition
     {
         return new Composition(

--- a/tests/PathableTest.php
+++ b/tests/PathableTest.php
@@ -38,6 +38,22 @@ class PathableTest extends TestCase
         ], $result);
     }
 
+    public function test_it_finds_whether_a_path_exists()
+    {
+        $composition = $this->makeComposition();
+
+        $this->assertTrue($composition->pathExists('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value'));
+        $this->assertFalse($composition->pathExists('test'));
+    }
+
+    public function test_it_finds_whether_a_path_is_unique()
+    {
+        $composition = $this->makeComposition();
+
+        $this->assertTrue($composition->pathUnique('content[test-EVALUATION.test.v0]/data'));
+        $this->assertFalse($composition->pathUnique('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value'));
+    }
+
     private function makeComposition(): Composition
     {
         return new Composition(


### PR DESCRIPTION
Implements the `pathExists()` and `pathUnique()` methods of the `Pathable` class from https://specifications.openehr.org/releases/RM/latest/common.html#_pathable_class

Also fixes an issue where `PathQuery::findList()` could return an array containing `null` instead of an empty array.