### PR TITLE
[BREAKING] ensure itemAtPath accesses unique value only 

### DIFF
--- a/src/PathQuery.php
+++ b/src/PathQuery.php
@@ -46,11 +46,11 @@ class PathQuery
             $attributePattern = '(?<attribute_name>\w+)';
             $predicatePattern = '(?<predicate>\[(?<expression>[\w.-]+)\])?';
             if (preg_match('/^' . $attributePattern . $predicatePattern . '$/', $segment, $matches) !== 1) {
-                throw new \Exception("Unable to parse path segment [$segment]");
+                throw new RuntimeException("Unable to parse path segment [$segment]");
             }
 
             if (! array_key_exists('attribute_name', $matches)) {
-                throw new \Exception("Unable to find attribute_name in path segment [$segment]");
+                throw new RuntimeException("Unable to find attribute_name in path segment [$segment]");
             }
 
             return $matches;

--- a/src/PathQuery.php
+++ b/src/PathQuery.php
@@ -4,6 +4,7 @@ namespace BigPictureMedical\OpenEhr;
 
 use BigPictureMedical\OpenEhr\Rm\Common\Archetyped\Pathable;
 use Illuminate\Support\Collection;
+use RuntimeException;
 
 class PathQuery
 {
@@ -11,7 +12,13 @@ class PathQuery
 
     public function find(Pathable $root): mixed
     {
-        return $this->findList($root)[0] ?? null;
+        $items = $this->findList($root);
+
+        if (count($items) > 1) {
+            throw new RuntimeException('Found multiple items at path. Found '.count($items).', expected 1.');
+        }
+
+        return $items[0] ?? null;
     }
 
     public function findList(Pathable $root): array

--- a/tests/PathQueryTest.php
+++ b/tests/PathQueryTest.php
@@ -13,6 +13,7 @@ use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\CodePhrase;
 use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvCodedText;
 use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvText;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class PathQueryTest extends TestCase
 {
@@ -20,10 +21,21 @@ class PathQueryTest extends TestCase
     {
         $composition = $this->makeComposition();
 
-        $result = (new PathQuery('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value'))
+        $result = (new PathQuery('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0004]/value/value'))
             ->find($composition);
 
-        $this->assertSame('Test value 1', $result);
+        $this->assertSame('Test unique value', $result);
+    }
+
+    public function test_it_throws_when_find_has_multiple_results()
+    {
+        $composition = $this->makeComposition();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Found multiple items at path. Found 4, expected 1.');
+
+        (new PathQuery('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value'))
+            ->find($composition);
     }
 
     public function test_it_handles_missing_paths_when_finding_a_single_item()
@@ -110,6 +122,11 @@ class PathQueryTest extends TestCase
                                         archetype_node_id: 'at0003',
                                         name: new DvText(value: 'Test element'),
                                         value: new DvText(value: 'Test value 2')
+                                    ),
+                                    new Element(
+                                        archetype_node_id: 'at0004',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test unique value')
                                     ),
                                 ]
                             ),

--- a/tests/PathableTest.php
+++ b/tests/PathableTest.php
@@ -12,6 +12,7 @@ use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\CodePhrase;
 use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvCodedText;
 use BigPictureMedical\OpenEhr\Rm\DataTypes\Text\DvText;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class PathableTest extends TestCase
 {
@@ -19,9 +20,19 @@ class PathableTest extends TestCase
     {
         $composition = $this->makeComposition();
 
-        $result = $composition->itemAtPath('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value');
+        $result = $composition->itemAtPath('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0004]/value/value');
 
-        $this->assertSame('Test value 1', $result);
+        $this->assertSame('Test unique value', $result);
+    }
+
+    public function test_it_throws_when_find_has_multiple_results()
+    {
+        $composition = $this->makeComposition();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Found multiple items at path. Found 4, expected 1.');
+
+        $composition->itemAtPath('content[test-EVALUATION.test.v0]/data/items[at0002]/items[at0003]/value/value');
     }
 
     public function test_it_finds_items_at_path()
@@ -72,6 +83,11 @@ class PathableTest extends TestCase
                                         archetype_node_id: 'at0003',
                                         name: new DvText(value: 'Test element'),
                                         value: new DvText(value: 'Test value 2')
+                                    ),
+                                    new Element(
+                                        archetype_node_id: 'at0004',
+                                        name: new DvText(value: 'Test element'),
+                                        value: new DvText(value: 'Test unique value')
                                     ),
                                 ]
                             ),


### PR DESCRIPTION
As per [the openEHR docs](https://specifications.openehr.org/releases/RM/latest/common.html#_pathable_class)

> The item at a path (relative to this item); only valid for unique paths, i.e. paths that resolve to a single item.

`itemAtPath` will now throw an exception if it gets more than one result.