### PR TITLE
Support spatie/data-transfer-object ^3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "big-picture-medical/openehr-data-structures",
     "require": {
-        "spatie/data-transfer-object": "^3.3",
+        "spatie/data-transfer-object": "^3.5",
         "symfony/finder": "^5.2",
         "illuminate/support": "^8.21"
     },

--- a/src/TypeableArrayCaster.php
+++ b/src/TypeableArrayCaster.php
@@ -9,18 +9,18 @@ use TypeError;
 class TypeableArrayCaster implements Caster
 {
     public function __construct(
-        private $type,
+        private array $types,
         private string $itemType,
     ) {
     }
 
     public function cast(mixed $value): mixed
     {
-        if ($this->type !== 'array') {
+        if (count($this->types) !== 1 || $this->types[0] !== 'array') {
             throw new RuntimeException('Can only cast arrays');
         }
 
-        $caster = new TypeableDataTransferObjectCaster($this->itemType);
+        $caster = new TypeableDataTransferObjectCaster([$this->itemType]);
 
         return array_map(fn ($item) => $this->validate($caster->cast($item)), $value);
     }


### PR DESCRIPTION
[spatie/data-transfer-object 3.5](https://github.com/spatie/data-transfer-object/releases/tag/3.5.0) changed the way the type is passed to casters so that it's now an array.

This PR adds support for 3.5 and drops support for previous versions.